### PR TITLE
change default encoding to utf8

### DIFF
--- a/VoidList.cs
+++ b/VoidList.cs
@@ -166,7 +166,7 @@ namespace VoidList
                             ImGui.InputText(reason, buff, 128);
                             if (ImGui.Button("Void Player"))
                             {
-                                voidList.Add(new Void(actor, System.Text.Encoding.Default.GetString(buff)));
+                                voidList.Add(new Void(actor, System.Text.Encoding.UTF8.GetString(buff)));
                                 buff = new byte[128];
                             }
                         }


### PR DESCRIPTION
So this can log void reason in characters of other languages (such as Chinese).